### PR TITLE
Add a global setting 'misMatchPercentage' to define a KO test beyond thi...

### DIFF
--- a/src/image.generator.coffee
+++ b/src/image.generator.coffee
@@ -64,7 +64,7 @@ _.extend ImageGenerator,
         compares[_case.browser] = compares[_case.browser] || {}
         compares[_case.browser][_case.key()] = _case.result
 
-        differences.push _case if _case.result.misMatchPercentage isnt 0
+        differences.push _case if _case.result.misMatchPercentage > _case.misMatchPercentage
         totalAnalysisTime += _case.result.analysisTime
       else
         differences.push _case

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -23,5 +23,5 @@ if config.reportFormat == 'file'
   # generate report.json  
   viff.on 'after', (cases, duration) -> imgGen.generateReport cases
 
-cases = Viff.constructCases config.browsers, config.envHosts, config.paths
+cases = Viff.constructCases config.browsers, config.envHosts, config.paths, config.misMatchPercentage
 viff.run cases

--- a/src/process.argv.coffee
+++ b/src/process.argv.coffee
@@ -24,14 +24,15 @@ parseEnvHosts = (value) ->
 parsePaths = (value) ->
   (p.trim() for p in value.split(',') when !_.isEmpty(p.trim()))
 
-mergeAndValidateConfig = (seleniumHost, browsers, envHosts, paths, reportFormat, grep, config) ->
+mergeAndValidateConfig = (seleniumHost, browsers, envHosts, paths, reportFormat, grep, misMatchPercentage, config) ->
   c = _.extend {}, config
 
-  for name, idx in ['seleniumHost', 'browsers', 'envHosts', 'paths', 'reportFormat', 'grep']
+  for name, idx in ['seleniumHost', 'browsers', 'envHosts', 'paths', 'reportFormat', 'grep', 'misMatchPercentage']
     c[name] = arguments[idx] || c[name]
 
   c.browsers = ['firefox'] if c.browsers is undefined or c.browsers.length == 0
   c.reportFormat = 'html' if c.reportFormat is undefined
+  c.misMatchPercentage = 0 if c.misMatchPercentage is undefined
 
   throw new Error('--selenium-host isn\'t set correctly') if c.seleniumHost is undefined
   throw new Error('-envs aren\'t set correctly.') if c.envHosts is undefined or _.keys(c.envHosts).length < 1
@@ -98,6 +99,9 @@ processArgv = (args) ->
         when '--selenium-host'
           seleniumHost = args.shift().trim()
 
+        when '-misMatchPercentage'
+          misMatchPercentage = args.shift().trim()
+
         when '-grep'
           grep = args.shift().trim()
 
@@ -105,7 +109,7 @@ processArgv = (args) ->
           if arg.indexOf('.config.js') > 0
             config = require path.resolve process.cwd(), arg
 
-  c = mergeAndValidateConfig seleniumHost, browsers, envHosts, paths, reportFormat, grep, config
+  c = mergeAndValidateConfig seleniumHost, browsers, envHosts, paths, reportFormat, grep, misMatchPercentage, config
   c.paths = filterByGrep(c.paths, grep) if grep
   c
 

--- a/src/testcase.coffee
+++ b/src/testcase.coffee
@@ -3,7 +3,7 @@ Capability = require './capability'
 
 class Testcase
 
-  constructor: (capablityFrom, capabilityTo, hostFrom, hostTo, nameFrom, nameTo, @url) ->
+  constructor: (capablityFrom, capabilityTo, hostFrom, hostTo, nameFrom, nameTo, @url, @misMatchPercentage) ->
 
     capablityFrom = new Capability capablityFrom
     capabilityTo = new Capability capabilityTo


### PR DESCRIPTION
Add a global setting 'misMatchPercentage' to define a KO test beyond this percentage (default is 0%).

A comparison of images may sometimes be slightly different (an offset of 1 pixel). In our case we want to identify a significant difference between two images and therefore put a test KO when the percentage difference is beyond a given threshold.
