### PR TITLE
npm install failed on windows

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+if ! which "cake" > /dev/null; then
+  node_modules/coffee-script/bin/cake build
+else
+  cake build
+fi

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "viffserver": "./bin/viffserver"
   },
   "scripts": {
-    "build": "node_modules/coffee-script/bin/cake build",
+    "build": "./build.sh",
     "install": "npm run build",
     "test": "npm install && grunt default"
   }


### PR DESCRIPTION
on windows will through "node_modules/coffee-script/bin/cake" command not found error.

use a shell instead.
